### PR TITLE
Bugfix for rects, some new functions (#67)

### DIFF
--- a/exact/exact/annotations/static/annotations/js/boundingboxes.js
+++ b/exact/exact/annotations/static/annotations/js/boundingboxes.js
@@ -758,7 +758,7 @@ class BoundingBoxes {
         var imagePoint = new paper.Point(this.viewer.viewport.viewportToImageCoordinates(viewportPoint));
 
         var canvasObject = undefined;
-        var selection_hit_type = 'fill';
+        var selection_hit_type = 'new';
         switch (selected_annotation_type.vector_type) {
             case 2:  // POINT or Elipse
                 var rectangle = new paper.Rectangle(imagePoint,
@@ -778,7 +778,6 @@ class BoundingBoxes {
             case 4:  // MULTI_LINE
                 canvasObject = new paper.Path(imagePoint);
                 canvasObject.data.type = "multi_line";
-                selection_hit_type = 'new';
 
                 break;
             case 5:  // POLYGON
@@ -787,7 +786,6 @@ class BoundingBoxes {
                 });
                 canvasObject.add(imagePoint);
                 canvasObject.data.type = "poly";
-                selection_hit_type = 'new';
                 break;
 
             case 1:  // Rect
@@ -816,7 +814,10 @@ class BoundingBoxes {
         canvasObject.data.area_hit_test = selected_annotation_type.area_hit_test;
 
         if (selected_annotation_type.area_hit_test)
-            canvasObject.fillColor = new paper.Color(0, 0, 0, 0.000001);
+        {
+            canvasObject.fillColor = selected_annotation_type.color_code
+            canvasObject.fillColor.alpha = $('#OpacitySlider')[0].value
+        }
 
 
         // bounding box coordinates
@@ -857,6 +858,8 @@ class BoundingBoxes {
             return;
         }
 
+        var opacity = $('#OpacitySlider')[0].value
+
         switch (annotation.annotation_type.vector_type) {
             case 1:  // Rect
                 var rect = new paper.Path.Rectangle(annotation.vector.x1, annotation.vector.y1,
@@ -866,7 +869,11 @@ class BoundingBoxes {
                 rect.strokeWidth = this.strokeWidth;
                 rect.name = annotation.unique_identifier;
                 if (annotation.annotation_type.area_hit_test)
-                    rect.fillColor = new paper.Color(0, 0, 0, 0.000001);
+                {
+                    rect.fillColor = annotation.annotation_type.color_code
+                    rect.fillColor.alpha = opacity
+                }
+                    
                 rect.data.type = "rect";
                 rect.data.type_id = annotation.annotation_type.id;
                 rect.data.area_hit_test = annotation.annotation_type.area_hit_test;
@@ -884,7 +891,11 @@ class BoundingBoxes {
                 rect.strokeWidth = this.strokeWidth;
                 rect.name = annotation.unique_identifier;
                 if (annotation.annotation_type.area_hit_test)
-                    rect.fillColor = new paper.Color(0, 0, 0, 0.000001);
+                {
+                    rect.fillColor = annotation.annotation_type.color_code
+                    rect.fillColor.alpha = opacity
+                }
+
                 rect.data.type = "fixed_rect";
                 rect.data.type_id = annotation.annotation_type.id;
                 rect.data.area_hit_test = annotation.annotation_type.area_hit_test;
@@ -901,7 +912,11 @@ class BoundingBoxes {
                 ellipse.strokeWidth = this.strokeWidth;
                 ellipse.name = annotation.unique_identifier;
                 if (annotation.annotation_type.area_hit_test)
-                    ellipse.fillColor = new paper.Color(0, 0, 0, 0.000001);
+                {
+                    ellipse.fillColor = annotation.annotation_type.color_code
+                    ellipse.fillColor.alpha = opacity
+                }
+
                 ellipse.data.type = "circle";
                 ellipse.data.type_id = annotation.annotation_type.id;
                 ellipse.data.area_hit_test = annotation.annotation_type.area_hit_test;
@@ -932,7 +947,10 @@ class BoundingBoxes {
                     closed: annotation.annotation_type.closed,
                 });
                 if (annotation.annotation_type.area_hit_test)
-                    poly.fillColor = new paper.Color(0, 0, 0, 0.000001);
+                {
+                    poly.fillColor = annotation.annotation_type.color_code
+                    poly.fillColor.alpha = opacity
+                }
 
                 poly.data.type = "poly";
                 poly.data.type_id = annotation.annotation_type.id;
@@ -950,13 +968,14 @@ class BoundingBoxes {
 
     updateAnnotationVisibility(unique_identifier, visibility) {
         var item = this.getItemFromUUID(unique_identifier);
+        var opacity = $('#OpacitySlider')[0].value
 
         if (item !== undefined) {
             if (visibility === true && item.data.area_hit_test === true) {
-                item.fillColor = new paper.Color(0, 0, 0, 0.000001);
+                item.fillColor.alpha = opacity
             }
             else if (visibility === false){
-                item.fillColor = new paper.Color(0, 0, 0, 0);
+                item.fillColor.alpha = 0
             }
 
 
@@ -965,14 +984,15 @@ class BoundingBoxes {
     }
 
     updateVisbility(annotation_type_id, visibility ) {
+        var opacity = $('#OpacitySlider')[0].value
 
         this.group.children.filter(function (el) {return el.data.type_id === parseInt(annotation_type_id)})
             .forEach(function (el) {
                 if (visibility === true && el.data.area_hit_test === true) {
-                    el.fillColor = new paper.Color(0, 0, 0, 0.000001);
+                    el.fillColor.alpha = opacity
                 }
                 else if (visibility === false){
-                    el.fillColor = new paper.Color(0, 0, 0, 0);
+                    el.fillColor.alpha = 0
                 }
 
 
@@ -1033,6 +1053,14 @@ class BoundingBoxes {
         }
 
         this.group.children.forEach(x => { x.strokeWidth = this.strokeWidth });
+    }
+
+    updateOpacity(opacity)
+    {
+        if( opacity!= null )
+        {
+            this.group.children.filter(el => el._data.area_hit_test).forEach(el => el.fillColor.alpha = opacity)
+        }
     }
 
     showItem(annotation) {
@@ -1248,7 +1276,10 @@ class BoundingBoxes {
         canvasObject.data.area_hit_test = annotation_type.area_hit_test;
 
         if (annotation_type.area_hit_test)
-            canvasObject.fillColor = new paper.Color(0, 0, 0, 0.000001);
+        {
+            canvasObject.fillColor = annotation_type.color_code
+            canvasObject.fillColor.alpha = $('#OpacitySlider')[0].value
+        }
 
         var tempName = item.name;
 
@@ -1280,8 +1311,6 @@ class BoundingBoxes {
 
             // Convert from viewport coordinates to image coordinates.
             var imagePoint = new paper.Point(this.viewer.viewport.viewportToImageCoordinates(viewportPoint));
-
-            var allowMovement = $("#allow_annotation_movement").is(':checked')
 
             switch (this.selection.item.data.type) {
                                                 
@@ -1319,7 +1348,7 @@ class BoundingBoxes {
                             this.drag.segment.segment.point = this.fixPointToImage(imagePoint)
                             this.drag.performed = true
                         }
-                        else if (allowMovement && (this.selection.item.contains(imagePoint) || this.drag.performed)) 
+                        else if (this.selection.item.contains(imagePoint) || this.drag.performed)
                         {
                             // move the polygon
                             var x_diff = imagePoint.x - this.drag.lastPos.x
@@ -1395,7 +1424,7 @@ class BoundingBoxes {
 
                 case 'fixed_rect':
 
-                    if (allowMovement && (this.selection.item.contains(imagePoint) || this.drag))
+                    if (this.selection.item.contains(imagePoint) || this.drag)
                     {
                         var x_diff = imagePoint.x - this.drag.lastPos.x
                         var y_diff = imagePoint.y - this.drag.lastPos.y
@@ -1482,7 +1511,7 @@ class BoundingBoxes {
                         this.drag.performed = true
                         
                     }
-                    else if (allowMovement && (this.selection.item.contains(imagePoint) || this.drag.performed)){
+                    else if (this.selection.item.contains(imagePoint) || this.drag.performed){
                         // the rect is moved
                         var x_diff = imagePoint.x - this.drag.lastPos.x
                         var y_diff = imagePoint.y - this.drag.lastPos.y

--- a/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
+++ b/exact/exact/annotations/static/annotations/js/exact-image-viewer.js
@@ -405,6 +405,10 @@ class EXACTViewer {
         return;
     }
 
+    handleKeyDown(event){
+        return
+    }
+
     initUiEvents() {
         return;
     }
@@ -581,11 +585,12 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
                     event.userData.deleteAnnotation()
                 else
                     event.userData.tool.resetSinglePolyOperation()
-                    event.userData.tool.resetMultiPolyOperation()
 
                 event.userData.do_finishAnnotation();
 
             }
+
+            event.userData.tool.resetMultiPolyOperation()
         }, this);
 
         viewer.addHandler("selection_cancel", function (event) {
@@ -990,6 +995,14 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
                 }
         }
     }
+    
+    handleKeyDown(event)
+    {
+        if(this.viewer.selectionInstance.isSelecting)
+        {
+            this.viewer.innerTracker.keyDownHandler(event)
+        }
+    }
 
     initToolEventHandler(viewer) {
 
@@ -1002,10 +1015,12 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
 
 
         $(document).keyup(this.handleKeyUp.bind(this));
+        $(document).keydown(this.handleKeyDown.bind(this));
         $('select#annotation_type_id').change(this.changeAnnotationTypeByComboxbox.bind(this));
 
         // tool events
         $('#StrokeWidthSlider').on("input", this.updateStrokeWidth.bind(this));
+        $('#OpacitySlider').on("input", this.updateOpacity.bind(this));
 
         for (let annotation_type of Object.values(annotation_types)) {
 
@@ -1424,13 +1439,22 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
         }
     }
 
-    updateStrokeWidth(value) {
-
-        if (value.hasOwnProperty('originalEvent')) {
-            value = value.valueAsNumber
+    updateStrokeWidth(event) {
+        var value
+        if (event.hasOwnProperty('originalEvent')) {
+            value = event.target.valueAsNumber
         }
 
         this.tool.updateStrokeWidth(value);
+    }
+
+    updateOpacity(event){
+        var value
+        if (event.hasOwnProperty('originalEvent')) {
+            value = event.target.valueAsNumber
+        }
+
+        this.tool.updateOpacity(value);
     }
 
     appendAction(action)
@@ -1498,6 +1522,7 @@ class EXACTViewerLocalAnnotations extends EXACTViewer {
         $(document).off("keyup");
         $('select#annotation_type_id').off("change");
         $('#StrokeWidthSlider').off("input");
+        $('#OpacitySlider').off("input");
         for (let annotation_type of Object.values(this.annotationTypes)) {
 
             $('#DrawCheckBox_' + annotation_type.id).off("change");

--- a/exact/exact/annotations/templates/annotations/annotate.html
+++ b/exact/exact/annotations/templates/annotations/annotate.html
@@ -728,6 +728,10 @@
                                     <input id="StrokeWidthSlider" type="range" class="custom-range" min="1" max="500"
                                         step="1" value="5" />
                                     <label for="StrokeWidthSlider">Stroke</label>
+
+                                    <input id="OpacitySlider" type="range" class="custom-range" min="0.01" max="1.0"
+                                        step="0.01" value="0.0" />
+                                    <label for="OpacitySlider">Opacity</label>
                                 </div>
 
                                 <div class="col-md-2">
@@ -750,10 +754,6 @@
                                     </select>
                                 </div>
                             </div>
-                        </tr>
-                        <tr>
-                            <input type="checkbox" id="allow_annotation_movement" checked="true">
-                            Allow Annotation Movement
                         </tr>
                     </div>
                 </div>


### PR DESCRIPTION
* Added checkbox to toggle the moving of annotations. Adjusted selection routine to selecte overlapping annotations

* Added images for scissor functionality

* Removed png images due to scaling issues

* Added scissors svg as image for new functionality

* Addes single polygon mode. Changed interaction behaviour

* Minor Bugfixes for reference errors

* Addes empty functions for scissors and glue

* Implemented functions calls for new functionalitys

* Implemented Scissor operation, fixed some bugs

* Added image of a glue stick. Added glue botton

* Added check whether verified_by_user already exisxts

* Implemented glue functionality

* Fixed some interactions issues

* Fixed bug where a annotation was not saved

* Removed unnessesary function call

* Added check to forbid to small polygons

* Fixed bug with the selection of objects

* Blocked call of finish annotation during singlePolyOperation

* Fixed hitTest function

* Added handeling of singlePolyOperations for cancelEditAnnotation

* Fixed SinglePolyOperation when selection is turned off

* Added hotkeys to activate singlePoylOperations

* Added/Updated images for scissors and glue

* Color of images changes when singlePolyMode is active. Minor bugfixes

* Major improvements in code quality

* Fixed all functions for mouseDrag

* Fixed Bug with Enter key

* Changed resizing behaviour of rects. Made hit test more flexible

* Update exact-image-viewer.js

* Renamed button dict for more accurate naming

* Added images for knife operation

* Change name of singlePolyOperation

* Renamed polyModify into singlePolyOperation

* Changed name of polyModify to singlePolyOperation

* Added activation/deactivation code for multiPolyOperations

* Minor renamings, added code to create multi_lines

* Added implementation of cut functionality

* Added hotkey to knife operation

* Fixed knife activation by hotkey

* Initial version of undo-function

* Minor bugfixes

* Fixed bug with creation of new rects

Fixed a bug where new rects were not synchronized with the exact server

* Added handling of filled objects

* Allowed movent of viewport during annotation with arrow-keys

Co-authored-by: Christian Marzahl <christian.marzahl@gmail.com>